### PR TITLE
Fix regex on Windows

### DIFF
--- a/src/file-manager.js
+++ b/src/file-manager.js
@@ -2,7 +2,7 @@ var path = require("path");
 var jspm = require("jspm");
 
 function resolveURL(filename) {
-  return filename.replace(/^file:\/\//, "").replace(/^([a-zA-Z])\//, "$1:/").replace(/\//g, path.sep);
+  return filename.replace(/^file:\/\//, "").replace(/^\/([a-zA-Z]:)\//, "$1/").replace(/^([a-zA-Z])\//, "$1:/").replace(/\//g, path.sep);
 }
 
 exports.factory = function(less) {


### PR DESCRIPTION
The regex in resolveURL didn't work in Windows, it didn't handle URLs in the form `file:///C:/Path/file`.

This addition to the regex fixes that.
